### PR TITLE
github-actions: ubuntu-20.04 will be fully retired by April 1 and macos-11/12 are not accessible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-latest']
+        os: ['ubuntu-22.04', 'ubuntu-latest']
         go: ['1.17', '1.22']
     runs-on: '${{ matrix.os }}'
     steps:
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-11', 'macos-latest']
+        os: ['macos-13', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v4'


### PR DESCRIPTION
See https://github.com/actions/runner-images

And https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/